### PR TITLE
Fixes for compatibility with MAU 4.35

### DIFF
--- a/MSUpdateHelper4JamfPro.sh
+++ b/MSUpdateHelper4JamfPro.sh
@@ -187,7 +187,8 @@ function DetermineLoginState() {
 		CMD_PREFIX=""
 	else
     	echo "User $CONSOLE is logged in"
-    	CMD_PREFIX="sudo -u $CONSOLE "
+    	userID=$(/usr/bin/id -u "$CONSOLE")
+	CMD_PREFIX="/bin/launchctl asuser $userID "
 	fi
 	Debug "Resolved CMD_PREFIX: $CMD_PREFIX"
 }

--- a/MSUpdateTrigger.sh
+++ b/MSUpdateTrigger.sh
@@ -89,10 +89,12 @@ function DetermineLoginState() {
 		echo "No user currently logged in to console - using fall-back account"
         CONSOLE=$(/usr/bin/last -1 -t ttys000 | /usr/bin/awk '{print $1}')
         echo "Using account $CONSOLE for update"
-		CMD_PREFIX="/usr/bin/sudo -u $CONSOLE "
+		userID=$(/usr/bin/id -u "$CONSOLE")
+		CMD_PREFIX="/bin/launchctl asuser $userID "
 	else
     	echo "User $CONSOLE is logged in"
-    	CMD_PREFIX="/usr/bin/sudo -u $CONSOLE "
+    		userID=$(/usr/bin/id -u "$CONSOLE")
+		CMD_PREFIX="/bin/launchctl asuser $userID "
 	fi
 }
 


### PR DESCRIPTION
Change from sudo -u to launchctl asuser for compatibility with XPC changes in MAU 4.35. Credit to user @Joyrex who reported the workaround in the #microsoft-autoupdate channel of the MacAdmins Slack